### PR TITLE
Feat: request id on logs

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,6 +18,8 @@ const (
 
 //Logger is our contract for the logger
 type Logger interface {
+	AddField(fieldName, msg string)
+
 	Debug(msg string)
 	Debugw(msg string, keysAndValues ...interface{})
 	Debugf(template string, args ...interface{})
@@ -86,6 +88,16 @@ func getBaseFields(baseFields BaseFields) map[string]interface{} {
 	}
 
 	return initFields
+}
+
+// Instantiated checks if the logger is instantiated
+func Instantiated() bool {
+	return log != nil
+}
+
+// AddField adds a field that will be logged on every subsequent log in the application
+func AddField(fieldName, msg string) {
+	log.AddField(fieldName, msg)
 }
 
 // Debug log a debug message.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,6 +3,9 @@ package logger
 // A global variable so that log functions can be directly accessed
 var log Logger
 
+// A global variable that represents the original version of the logger, defined when the logger is instantiated for the first time
+var origLog Logger
+
 const (
 	// DEBUG has verbose message
 	DEBUG = "debug"
@@ -18,7 +21,7 @@ const (
 
 //Logger is our contract for the logger
 type Logger interface {
-	AddField(fieldName, msg string) *zapLogger
+	AddRequestID(requestID string) *zapLogger
 
 	Debug(msg string)
 	Debugw(msg string, keysAndValues ...interface{})
@@ -46,7 +49,9 @@ type Logger interface {
 }
 
 func init() {
-	log, _ = newZapLogger(Configuration{})
+	logger, _ := newZapLogger(Configuration{})
+	log = logger
+	origLog = logger
 }
 
 // BaseFields represents the base fields for create the basic fields of logger.
@@ -71,6 +76,7 @@ func NewLogger(config Configuration) error {
 		return err
 	}
 	log = logger
+	origLog = logger
 	return nil
 }
 
@@ -95,9 +101,15 @@ func Instantiated() bool {
 	return log != nil
 }
 
-// AddField adds a field that will be logged on every subsequent log in the application
-func AddField(fieldName, msg string) {
-	log = log.AddField(fieldName, msg)
+// AddRequestID adds a request_id field that will be logged on every subsequent log in the application
+func AddRequestID(requestID string) {
+	clearLogFields()
+	log = log.AddRequestID(requestID)
+}
+
+// returns the log variable to its original state, clearing any previously added extra fields
+func clearLogFields() {
+	log = origLog
 }
 
 // Debug log a debug message.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,7 +18,7 @@ const (
 
 //Logger is our contract for the logger
 type Logger interface {
-	AddField(fieldName, msg string)
+	AddField(fieldName, msg string) *zapLogger
 
 	Debug(msg string)
 	Debugw(msg string, keysAndValues ...interface{})
@@ -97,7 +97,7 @@ func Instantiated() bool {
 
 // AddField adds a field that will be logged on every subsequent log in the application
 func AddField(fieldName, msg string) {
-	log.AddField(fieldName, msg)
+	log = log.AddField(fieldName, msg)
 }
 
 // Debug log a debug message.

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -62,7 +62,11 @@ func newZapLogger(config Configuration) (Logger, error) {
 }
 
 func (l *zapLogger) AddField(fieldName, msg string) {
-	l.sugaredLogger.With(fieldName, msg)
+	logger := &zapLogger{
+		sugaredLogger: l.sugaredLogger.With(fieldName, msg),
+	}
+
+	l = logger
 }
 
 func (l *zapLogger) Debug(msg string) {

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -61,6 +61,10 @@ func newZapLogger(config Configuration) (Logger, error) {
 	}, nil
 }
 
+func (l *zapLogger) AddField(fieldName, msg string) {
+	l.sugaredLogger.With(fieldName, msg)
+}
+
 func (l *zapLogger) Debug(msg string) {
 	l.sugaredLogger.Debug(msg)
 }

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -61,12 +61,10 @@ func newZapLogger(config Configuration) (Logger, error) {
 	}, nil
 }
 
-func (l *zapLogger) AddField(fieldName, msg string) {
-	logger := &zapLogger{
+func (l *zapLogger) AddField(fieldName, msg string) *zapLogger {
+	return &zapLogger{
 		sugaredLogger: l.sugaredLogger.With(fieldName, msg),
 	}
-
-	l = logger
 }
 
 func (l *zapLogger) Debug(msg string) {

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -5,6 +5,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// represents the request id field on the log body
+const requestIDField = "request_id"
+
 type zapLogger struct {
 	sugaredLogger *zap.SugaredLogger
 }
@@ -61,9 +64,9 @@ func newZapLogger(config Configuration) (Logger, error) {
 	}, nil
 }
 
-func (l *zapLogger) AddField(fieldName, msg string) *zapLogger {
+func (l *zapLogger) AddRequestID(requestID string) *zapLogger {
 	return &zapLogger{
-		sugaredLogger: l.sugaredLogger.With(fieldName, msg),
+		sugaredLogger: l.sugaredLogger.With(requestIDField, requestID),
 	}
 }
 

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -28,7 +28,7 @@ func RequestID(headerName string) func(next http.Handler) http.Handler {
 			ctx = context.WithValue(ctx, RequestIDKey, requestID)
 
 			if logger.Instantiated() {
-				logger.AddField("request_id", requestID)
+				logger.AddRequestID(requestID)
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/delivery-much/dm-go/logger"
 	"github.com/google/uuid"
 )
 
@@ -13,7 +14,7 @@ type ctxKeyRequestID int
 // RequestIDKey is the key that holds the unique request ID in a request context.
 const RequestIDKey ctxKeyRequestID = 0
 
-// RequestID is a middleware that injects or create a request ID into the context of each
+// RequestID is a middleware that injects a request ID into the context and logger of each
 // request. A request ID is an UUID, example: 9e21998d-d36f-48ef-831b-30e643536c88.
 func RequestID(headerName string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -23,7 +24,13 @@ func RequestID(headerName string) func(next http.Handler) http.Handler {
 			if requestID == "" {
 				requestID = uuid.New().String()
 			}
+
 			ctx = context.WithValue(ctx, RequestIDKey, requestID)
+
+			if logger.Instantiated() {
+				logger.AddField("request_id", requestID)
+			}
+
 			next.ServeHTTP(w, r.WithContext(ctx))
 		}
 		return http.HandlerFunc(fn)


### PR DESCRIPTION
Adiciona uma lógica para adicionar automaticamente o requestID da requisição em todos os logs subsequentes da aplicação.
Dessa maneira será possível relacionar, no kibana, um log no meio do código com uma requisição de um usuário.

Essa adição é feita de maneira automática, pelo middleware RequestID, que já existe.

- Criação de um método no logger que adiciona um campo `"request_id"` aos próximos logs da aplicação
- Criação de um método que limpa os campos extras do log, para que esse `"request_id"` não seja duplicado nos logs das requisições
- Criação de um método que indica se o log está instanciado, para que o middleware RequestID não tente adicionar o campo caso o log seja nulo, evitando nil pointer error.
- Adição automática do campo "request_id"` aos logs da aplicação, no middleware RequestID.