### PR TITLE
bugfix: protext NoCTX logger from nil panic

### DIFF
--- a/logger/zap.go
+++ b/logger/zap.go
@@ -107,73 +107,109 @@ func (l *zapLogger) AddRequestID(requestID string) *zapLogger {
 }
 
 func (l *zapLogger) Debug(msg string) {
-	l.sugaredLogger.Debug(msg)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Debug(msg)
+	}
 }
 
 func (l *zapLogger) Debugw(msg string, keysAndValues ...interface{}) {
-	l.sugaredLogger.Debugw(msg, keysAndValues...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Debugw(msg, keysAndValues...)
+	}
 }
 
 func (l *zapLogger) Debugf(format string, args ...interface{}) {
-	l.sugaredLogger.Debugf(format, args...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Debugf(format, args...)
+	}
 }
 
 func (l *zapLogger) Info(msg string) {
-	l.sugaredLogger.Info(msg)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Info(msg)
+	}
 }
 
 func (l *zapLogger) Infow(msg string, keysAndValues ...interface{}) {
-	l.sugaredLogger.Infow(msg, keysAndValues...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Infow(msg, keysAndValues...)
+	}
 }
 
 func (l *zapLogger) Infof(format string, args ...interface{}) {
-	l.sugaredLogger.Infof(format, args...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Infof(format, args...)
+	}
 }
 
 func (l *zapLogger) Warn(msg string) {
-	l.sugaredLogger.Warn(msg)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Warn(msg)
+	}
 }
 
 func (l *zapLogger) Warnw(msg string, keysAndValues ...interface{}) {
-	l.sugaredLogger.Warnw(msg, keysAndValues...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Warnw(msg, keysAndValues...)
+	}
 }
 
 func (l *zapLogger) Warnf(format string, args ...interface{}) {
-	l.sugaredLogger.Warnf(format, args...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Warnf(format, args...)
+	}
 }
 
 func (l *zapLogger) Error(msg string) {
-	l.sugaredLogger.Error(msg)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Error(msg)
+	}
 }
 
 func (l *zapLogger) Errorw(msg string, keysAndValues ...interface{}) {
-	l.sugaredLogger.Errorw(msg, keysAndValues...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Errorw(msg, keysAndValues...)
+	}
 }
 
 func (l *zapLogger) Errorf(format string, args ...interface{}) {
-	l.sugaredLogger.Errorf(format, args...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Errorf(format, args...)
+	}
 }
 
 func (l *zapLogger) Fatal(msg string) {
-	l.sugaredLogger.Fatal(msg)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Fatal(msg)
+	}
 }
 
 func (l *zapLogger) Fatalw(msg string, keysAndValues ...interface{}) {
-	l.sugaredLogger.Fatalw(msg, keysAndValues...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Fatalw(msg, keysAndValues...)
+	}
 }
 
 func (l *zapLogger) Fatalf(format string, args ...interface{}) {
-	l.sugaredLogger.Fatalf(format, args...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Fatalf(format, args...)
+	}
 }
 
 func (l *zapLogger) Panic(msg string) {
-	l.sugaredLogger.Panic(msg)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Panic(msg)
+	}
 }
 
 func (l *zapLogger) Panicw(msg string, keysAndValues ...interface{}) {
-	l.sugaredLogger.Panicw(msg, keysAndValues...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Panicw(msg, keysAndValues...)
+	}
 }
 
 func (l *zapLogger) Panicf(format string, args ...interface{}) {
-	l.sugaredLogger.Panicf(format, args...)
+	if l.sugaredLogger != nil {
+		l.sugaredLogger.Panicf(format, args...)
+	}
 }


### PR DESCRIPTION
### Descrição
- Protege os logs sem contexto `NoCTX` de tentar acessar um logger nulo.
