### PR TITLE
do not add reqId to /health calls

### DIFF
--- a/optel/optel.go
+++ b/optel/optel.go
@@ -139,7 +139,9 @@ func newTraceExporter(ctx context.Context) (trace.SpanExporter, error) {
 func getReqIdMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		defer StartTrack(ctx, "ReqID")()
+		if r.URL.Path != "/health" {
+			defer StartTrack(ctx, "ReqID")()
+		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }


### PR DESCRIPTION
### Descrição
O middleware que adicionar reqID não irá atuar nos requests de `/health`

### Checklist
- [X] Foi executado localmente
- [X] Foi testado no ambiente de dev
- [ ] Foi escrito os testes necessários
- [ ] Documentação adicionada ao README (caso necessite)
- [X] Estou atribuído como owner do PR
- [X] Review solicitado para time correto
- [X] O `.env-example` está atualizado
- [X] O openapi está atualizado
